### PR TITLE
fix(github-action): '--rm-dist' is deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
as stated [here](https://goreleaser.com/deprecations/#__tabbed_17_1), we must move from `goreleaser release --rm-dist` to `goreleaser release --clean`.